### PR TITLE
Con 464 add yubihsm2 driver recipe 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/Containerfile
+++ b/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/Containerfile
@@ -1,0 +1,61 @@
+FROM registry.primekey.com/primekey/hsm-driver-base:0.4.25
+
+# Ref. https://developers.yubico.com/YubiHSM2/Releases/
+ARG DRIVER_DOWNLOAD_URL="https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-2022-06-centos7-amd64.tar.gz"
+ARG DRIVER_DOWNLOAD_CHECKSUM="6edb82375224f914910dcae9e0e7cef1d96f456be3311a25f7ff652d84cd0b71"
+
+# Yubico devs sign the SDK packages using OpenPGP keys, refer to that if you want to verify the signature
+# https://developers.yubico.com/Software_Projects/Software_Signing.html
+#ARG DRIVER_SIGNATURE="https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-2022-06-centos7-amd64.tar.gz.sig"
+
+USER 0:0
+
+RUN \
+    microdnf install --assumeyes pcsc-lite libedit ncurses-compat-libs compat-openssl10 tar
+
+COPY --chown=10001:0  ./opt/yubihsm2/ /opt/yubihsm2/
+
+RUN mkdir /opt/yubihsm2/packages && \
+    cd /opt/yubihsm2/packages && \
+    curl -sS -L "${DRIVER_DOWNLOAD_URL}" -o "yubihsm2-sdk.tar.gz" && \
+    sha256sum "yubihsm2-sdk.tar.gz" | grep "${DRIVER_DOWNLOAD_CHECKSUM}" && \
+    tar -xvf yubihsm2-sdk.tar.gz && \
+    cp yubihsm2-sdk/yubihsm-shell*.rpm . && \
+    ls -alh
+
+RUN rpm -Uvlh --force /opt/yubihsm2/packages/yubihsm-shell*.rpm && \
+    chown 10001:0 /usr/lib64/pkcs11/yubihsm_pkcs11.so
+
+# Clean up
+RUN \
+    rm -rf /opt/yubihsm2/packages && \
+    microdnf remove tar && \
+    microdnf clean all && \ 
+    rm -rf /var/cache/yum
+
+# Provide a VOLUME for the --volumes-from pattern
+VOLUME /opt/primekey/p11proxy-client/
+
+# Location of configuration file
+ENV YUBIHSM_PKCS11_CONF="/opt/yubihsm2/yubihsm_pkcs11.conf"
+
+# Initialize defaults
+ENV YUBIHSM_CONNECTOR=http://localhost:12345
+ENV YUBIHSM_DEBUG=false
+ENV YUBIHSM_STDOUT=false
+ENV YUBIHSM_DINOUT=false
+ENV YUBIHSM_LIBDEBUG=false
+ENV YUBIHSM_CACERT=false
+ENV YUBIHSM_PROXY=false
+ENV YUBIHSM_TIMEOUT=false
+
+# Path recommendation
+ENV PATH="/bin:/usr/bin"
+
+# Privilege recommendation (unprivileged user belonging to the root group) for execution
+USER 10001:0
+
+WORKDIR /opt
+
+# Use the start script from the base container and override setup using the environment-hsm file
+#CMD [...]

--- a/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/README.md
+++ b/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/README.md
@@ -1,0 +1,54 @@
+#### EJBCA EE Container integration with YubiHSM2
+
+##### Overview
+
+This example highlights building a side-car hsm-driver container on top of PrimeKey P11Proxy HSM base-driver, adding [YubiHSM2](https://www.yubico.com/products/hardware-security-module/) libraries and scripts.
+
+YubiHSM2 Connector represents the 'main uplink' to the physical USB HSM device, referenced from within the HSM-driver container. The Connector can be running on the same host or on a different one. It can also be running on an additional container layer.
+
+##### Deployment parameters
+
+The following environment variables will change the driver container behavior though the HSM config file:
+
+- YUBIHSM_CONNECTOR: Address & port to YubiHSM2 Connector
+    - Example: http://192.168.x.xxx:12345
+    - Default = http://localhost:12345
+- YUBIHSM_DEBUG: Set *true* to enable DEBUG level log
+    - Default: disabled
+- YUBIHSM_STDOUT: Set *true* to log everything to stdout
+    - Default: disabled (stderr)
+- YUBIHSM_DINOUT: Set *true* to enable function tracing (ingress/egress)
+    - Default: disabled
+- YUBIHSM_LIBDEBUG: Set *true* to enable libyubihsm debug output
+    - Default: disabled
+- YUBIHSM_CACERT: Enables HTTPS validation
+    - The value translates to a path at the container, e.g. /tmp/cacert.pem
+    - Default: disabled
+- YUBIHSM_PROXY: Add a proxy address
+    - Example: http://proxyserver.local.com:8080
+    - Default: disabled
+- YUBIHSM_TIMEOUT: Number of *seconds* for the initial connection to the Connector
+    - Must be a number
+    - Default: disabled
+
+Refer to [Yubico developers site](https://developers.yubico.com/YubiHSM2/Component_Reference/PKCS_11/) for more info about the configuration file.
+
+##### Deployment example
+
+Find docker-compose.yml that runs 2 layers while building one to be the side-car container. 
+
+Other layers can be added, i.e. for using an external database, DNS, reverse proxy, etc. or/and using YubiHSM Connector as a container as well.
+
+This assumes the Connector resides on the docker host (or a remote reachable machine):
+1. On the Connector host run with the network IP: `yubihsm-connector -l 192.168.x.xxx:12345`
+2. On the docker host, update the environment variables and run: `docker-compose up` or `docker compose up`
+
+##### Troubleshooting
+
+- Connector status can be inquired from the hsm-driver container
+    - Example: curl http://<IP/host/service>:12345/connector/status
+- A successful USB mounting *is essential* when using the Connector as a container layer
+    - Make sure the USB is plugged and accessible from the docker host first
+- Generating new keys from EJBCA UI is not supported currently
+    - Use yubihsm-shell to generate the keys in advance
+    - Follow [ECA-10312](https://jira.primekey.se/browse/ECA-10312) for related updates

--- a/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/docker-compose.yml
+++ b/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3'
+networks:
+  access-bridge:
+    driver: bridge
+  application-bridge:
+    driver: bridge
+services:
+  ejbca-ee:
+    container_name: ejbca-ee
+    image: "registry.primekey.com/primekey/ejbca-ee:7.10.0.1"
+    depends_on:
+      - hsm-driver-yubihsm2
+    networks:
+      - access-bridge
+      - application-bridge
+    environment:
+      - TLS_SETUP_ENABLED=later
+      - P11SERVER=hsm-driver-yubihsm2
+    volumes:
+      - hsm-driver:/opt/primekey/p11proxy-client
+    ports:
+      - "80:8080"
+      - "443:8443"
+  hsm-driver-yubihsm2:
+    container_name: hsm-driver-yubihsm2
+    image: "hsm-driver-yubihsm2:latest"
+    build:
+      context: .
+      dockerfile: Containerfile 
+    networks:
+      - application-bridge
+    environment:
+      - YUBIHSM_CONNECTOR=http://192.168.x.xxx:12345
+    volumes:
+      - hsm-driver:/opt/primekey/p11proxy-client
+volumes:
+  hsm-driver:
+  

--- a/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/opt/yubihsm2/environment-hsm
+++ b/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/opt/yubihsm2/environment-hsm
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+##################################################################
+#                                                                #
+# Copyright (c) 2018-2022 PrimeKey Solutions AB.                 #
+#                                                                #
+# This software is free software; you can redistribute it and/or #
+# modify it under the terms of the GNU Lesser General Public     #
+# License as published by the Free Software Foundation; either   #
+# version 2.1 of the License, or any later version.              #
+#                                                                #
+# See terms of license at gnu.org.                               #
+#                                                                #
+##################################################################
+
+baseDir="$1"
+tempDir="$2"
+
+# Configure the Connector
+if [ "$YUBIHSM_CONNECTOR" != "http://localhost:12345" ] ; then
+  sed -i "s|^connector = http://localhost:12345|connector = ${YUBIHSM_CONNECTOR}|g" "$YUBIHSM_PKCS11_CONF"   
+fi
+
+### Set up env
+
+# Logging
+if [ "$YUBIHSM_DEBUG" == "true" ] ; then
+  sed -i "s|^# debug|debug|g" "$YUBIHSM_PKCS11_CONF"
+fi
+
+if [ "$YUBIHSM_STDOUT" == "true" ] ; then
+  sed -i "s|^# debug-file = /dev/stdout|debug-file = /dev/stdout|g" "$YUBIHSM_PKCS11_CONF"
+fi
+
+if [ "$YUBIHSM_DINOUT" == "true" ] ; then
+  sed -i "s|^# dinout|dinout|g" "$YUBIHSM_PKCS11_CONF"
+fi
+
+if [ "$YUBIHSM_LIBDEBUG" == "true" ] ; then
+  sed -i "s|^# libdebug|libdebug|g" "$YUBIHSM_PKCS11_CONF"
+fi
+
+# Use CA cert
+if [ "$YUBIHSM_CACERT" != "false" ] ; then
+  sed -i "s|^# cacert = /tmp/cacert.pem|cacert = $YUBIHSM_CACERT|g" "$YUBIHSM_PKCS11_CONF"
+fi
+
+# Use a proxy
+if [ "$YUBIHSM_PROXY" != "false" ] ; then
+  sed -i "s|^# proxy = http://proxyserver.local.com:8080|proxy = $PROXY|g" "$YUBIHSM_PKCS11_CONF"
+fi
+
+# Set a timeout (Number)
+if [ -n "$YUBIHSM_TIMEOUT" ] && [ "$YUBIHSM_TIMEOUT" -eq "$YUBIHSM_TIMEOUT" ] 2>/dev/null; then
+  sed -i "s|^# timeout = 5|timeout = $YUBIHSM_TIMEOUT|g" "$YUBIHSM_PKCS11_CONF"
+fi
+
+# Also consumed by the p11proxy-server
+export HSM_PKCS11_LIBRARY="${HSM_PKCS11_LIBRARY:-/usr/lib64/pkcs11/yubihsm_pkcs11.so}"
+
+#export HSM_PKCS11_LIBRARY="${HSM_PKCS11_LIBRARY:-/usr/lib64/pkcs11/p11-kit-trust.so}"
+#export YUBIHSM_PKCS11_MODULE=$HSM_PKCS11_LIBRARY

--- a/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/opt/yubihsm2/yubihsm_pkcs11.conf
+++ b/hsm-integration/hsm-drivers/hsm-driver-yubihsm2/opt/yubihsm2/yubihsm_pkcs11.conf
@@ -1,0 +1,36 @@
+# This is a configuration file for the YubiHSM PKCS#11 module
+# Uncomment the various options as needed
+
+# URL of the connector to use. This can be a comma-separated list
+connector = http://localhost:12345
+
+# Enables general debug output in the module
+#
+# debug
+
+# Enables function tracing (ingress/egress) debug output in the module
+#
+# dinout
+
+# Enables libyubihsm debug output in the module
+#
+# libdebug
+
+# Redirects the debug output to a specific file. The file is created
+# if it does not exist. The content is appended
+#
+# debug-file = /dev/stdout
+
+# CA certificate to use for HTTPS validation. Point this variable to
+# a file containing one or more certificates to use when verifying
+# a peer. Currently not supported on Windows
+#
+# cacert = /tmp/cacert.pem
+
+# Proxy server to use for the connector
+# Currently not supported on Windows
+#
+# proxy = http://proxyserver.local.com:8080
+
+# Timeout in seconds to use for the initial connection to the connector
+# timeout = 5


### PR DESCRIPTION
Adding recipe example#2 for YubiHSM2 hsm-driver container, on top of primekey hsm base-driver. Running EJBCA EE 7.10.0.1 using P11NG, base driver version 0.4.25, and Yubico SDK version 2022.06.